### PR TITLE
Add link to privacyIDEA Google Group

### DIFF
--- a/readme
+++ b/readme
@@ -5,6 +5,8 @@ https://github.com/bytemine/webapp-privacyidea
 Zarafa Project site:
 https://community.zarafa.com/pg/plugins/project/34424/developer/dra/webappprivacyidea
 
+Community discussion about privacyIDEA:
+https://groups.google.com/forum/#!forum/privacyidea
 
 Code Repository:
 https://github.com/bytemine/webapp-privacyidea


### PR DESCRIPTION
The link should help users to get help for privacyIDEA basically but could also be about the webapp.